### PR TITLE
feat: apply gray theme with light blue borders

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -57,10 +57,11 @@
   /* solid */
 
   --jet: hsl(0, 0%, 22%);
-  --onyx: hsl(240, 1%, 17%);
-  --eerie-black-1: hsl(240, 2%, 13%);
-  --eerie-black-2: hsl(240, 2%, 12%);
-  --smoky-black: hsl(0, 0%, 7%);
+  --onyx: #3a3a3a;
+  --eerie-black-1: #4a4a4a;
+  --eerie-black-2: #5a5a5a;
+  --smoky-black: #2f2f2f;
+  --light-blue: #add8e6;
   --white-1: hsl(0, 0%, 100%);
   --white-2: hsl(0, 0%, 98%);
   --orange-yellow-crayola: hsl(45, 100%, 72%);
@@ -155,7 +156,7 @@ input, textarea {
 
 html { font-family: var(--ff-poppins); }
 
-body { background: var(--smoky-black); }
+body { background: var(--smoky-black); border: 5px solid var(--light-blue); }
 
 
 
@@ -168,7 +169,7 @@ body { background: var(--smoky-black); }
 .sidebar,
 article {
   background: var(--eerie-black-2);
-  border: 1px solid var(--jet);
+  border: 1px solid var(--light-blue);
   border-radius: 20px;
   padding: 15px;
   box-shadow: var(--shadow-1);
@@ -500,7 +501,7 @@ main {
   width: 100%;
   background: hsla(240, 1%, 17%, 0.75);
   backdrop-filter: blur(10px);
-  border: 1px solid var(--jet);
+  border: 1px solid var(--light-blue);
   border-radius: 12px 12px 0 0;
   box-shadow: var(--shadow-2);
   z-index: 5;
@@ -699,7 +700,7 @@ main {
   position: relative;
   padding: 15px;
   margin: 15px 12px;
-  border: 1px solid var(--jet);
+  border: 1px solid var(--light-blue);
   border-radius: 14px;
   box-shadow: var(--shadow-5);
   transform: scale(1.2);
@@ -859,7 +860,7 @@ main {
   width: 6px;
   background: var(--text-gradient-yellow);
   border-radius: 50%;
-  box-shadow: 0 0 0 4px var(--jet);
+  box-shadow: 0 0 0 4px var(--light-blue);
 }
 
 .timeline-text {
@@ -929,7 +930,7 @@ main {
   align-items: center;
   width: 100%;
   padding: 12px 16px;
-  border: 1px solid var(--jet);
+  border: 1px solid var(--light-blue);
   border-radius: 14px;
   font-size: var(--fs-6);
   font-weight: var(--fw-300);
@@ -943,7 +944,7 @@ main {
   top: calc(100% + 6px);
   width: 100%;
   padding: 6px;
-  border: 1px solid var(--jet);
+  border: 1px solid var(--light-blue);
   border-radius: 14px;
   z-index: 2;
   opacity: 0;
@@ -1172,7 +1173,7 @@ main {
   width: 100%;
   border-radius: 16px;
   margin-bottom: 30px;
-  border: 1px solid var(--jet);
+  border: 1px solid var(--light-blue);
   overflow: hidden;
 }
 
@@ -1201,7 +1202,7 @@ main {
   font-size: var(--fs-6);
   font-weight: var(--fw-400);
   padding: 13px 20px;
-  border: 1px solid var(--jet);
+  border: 1px solid var(--light-blue);
   border-radius: 14px;
   outline: none;
 }


### PR DESCRIPTION
## Summary
- restore original gray `--jet` color and add dedicated `--light-blue` variable
- update site borders and highlights to use the new light blue accent

## Testing
- `npm test` *(fails: Could not read package.json)*
- `python -m http.server & curl -I http://localhost:8000/`


------
https://chatgpt.com/codex/tasks/task_e_688da295c1948321ab6ebab3396e4960